### PR TITLE
data driven

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A rust-written backend lib for edit and generation of lattice 3D-
 readme = "README.md"
 homepage = "https://github.com/TonyWu20/castep-model-generator-backend"
 repository = "https://github.com/TonyWu20/castep-model-generator-backend"
-version = "2.0.14"
+version = "2.1.0"
 edition = "2021"
 license = "MIT"
 keywords = [
@@ -22,4 +22,4 @@ keywords = [
 nalgebra = {version="0.*", features=["debug", "compare", "rand","macros", "alloc", "arbitrary"]}
 serde_yaml = "0.8.*"
 serde = { version = "1.*", features = ["derive"] }
-castep-model-core = {path = "../castep-model-core"}
+castep-model-core = "0.2.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ keywords = [
 nalgebra = {version="0.*", features=["debug", "compare", "rand","macros", "alloc", "arbitrary"]}
 serde_yaml = "0.8.*"
 serde = { version = "1.*", features = ["derive"] }
-castep-model-core = "0.1.*"
+castep-model-core = {path = "../castep-model-core"}

--- a/src/assemble/mod.rs
+++ b/src/assemble/mod.rs
@@ -1,6 +1,7 @@
 /// Assemble adsorbate and lattice.
 use std::{f64::consts::PI, fmt::Debug, marker::PhantomData};
 
+use castep_model_core::atom::visitor::{get_multiple_xyz_by_id, get_xyz_by_id};
 use na::{Point3, Translation3, Unit, UnitQuaternion, Vector3};
 
 use crate::math_helper::{
@@ -312,21 +313,10 @@ where
                 if self.coord_atom_ids().len() == 1
                     && !stem_atom_ids.contains(&self.coord_atom_ids()[0])
                 {
-                    let coord_xyz = self
-                        .adsorbate()
-                        .get_atom_by_id(self.coord_atom_ids()[0])
-                        .unwrap()
-                        .xyz();
-                    let sa_xyz = self
-                        .adsorbate()
-                        .get_atom_by_id(stem_atom_ids[0])
-                        .unwrap()
-                        .xyz();
-                    let sb_xyz = self
-                        .adsorbate()
-                        .get_atom_by_id(stem_atom_ids[1])
-                        .unwrap()
-                        .xyz();
+                    let coord_xyz =
+                        get_xyz_by_id(self.adsorbate().atoms(), self.coord_atom_ids()[0]).unwrap();
+                    let sa_xyz = get_xyz_by_id(self.adsorbate().atoms(), stem_atom_ids[0]).unwrap();
+                    let sb_xyz = get_xyz_by_id(self.adsorbate().atoms(), stem_atom_ids[1]).unwrap();
                     let vector =
                         perpendicular_vec_through_a_point(coord_xyz, sa_xyz, sb_xyz).unwrap();
                     if vector.z < 0.0 {
@@ -357,16 +347,11 @@ where
         if let Some(stem_atom_ids) = self.stem_atom_ids() {
             // Run into a virtual stem vector is needed
             if stem_atom_ids[0] == stem_atom_ids[1] {
-                let stem_atom_xyz = self
-                    .adsorbate()
-                    .get_atom_by_id(stem_atom_ids[0])
-                    .unwrap()
-                    .xyz();
-                let plane_atom_xyz = self
-                    .adsorbate()
-                    .get_atom_by_id(self.plane_atom_ids().unwrap()[0]) // The existence of a plane is guaranteed
-                    .unwrap()
-                    .xyz();
+                let stem_atom_xyz =
+                    get_xyz_by_id(self.adsorbate().atoms(), stem_atom_ids[0]).unwrap();
+                let plane_atom_xyz =
+                    get_xyz_by_id(self.adsorbate().atoms(), self.plane_atom_ids().unwrap()[0])
+                        .unwrap();
                 // At this case, a plane is guaranteed
                 let plane_normal = self.get_plane_normal().unwrap();
                 let stem_intersects_plane = line_plane_intersect(
@@ -393,53 +378,33 @@ where
     }
     fn get_plane_normal(&self) -> Option<Vector3<f64>> {
         self.plane_atom_ids().map(|plane_atoms| {
-            plane_normal(
-                self.adsorbate()
-                    .get_atom_by_id(plane_atoms[0])
-                    .unwrap()
-                    .xyz(),
-                self.adsorbate()
-                    .get_atom_by_id(plane_atoms[1])
-                    .unwrap()
-                    .xyz(),
-                self.adsorbate()
-                    .get_atom_by_id(plane_atoms[2])
-                    .unwrap()
-                    .xyz(),
-            )
-            .unwrap()
+            let points: Vec<&Point3<f64>> =
+                get_multiple_xyz_by_id(self.adsorbate().atoms(), plane_atoms)
+                    .into_iter()
+                    .flatten()
+                    .collect();
+            let [point_1, point_2, point_3]: [&Point3<f64>; 3] = points.try_into().unwrap();
+            plane_normal(point_1, point_2, point_3).unwrap()
         })
     }
     fn move_to_origin(&mut self) {
         let curr_stem_centroid: Point3<f64> = if let Some(stem_atom_ids) = self.stem_atom_ids() {
             na::center(
-                self.adsorbate()
-                    .get_atom_by_id(stem_atom_ids[0])
-                    .unwrap()
-                    .xyz(),
-                self.adsorbate()
-                    .get_atom_by_id(stem_atom_ids[1])
-                    .unwrap()
-                    .xyz(),
+                get_xyz_by_id(self.adsorbate().atoms(), stem_atom_ids[0]).unwrap(),
+                get_xyz_by_id(self.adsorbate().atoms(), stem_atom_ids[1]).unwrap(),
             )
         } else {
-            *self.adsorbate().get_atom_by_id(1).unwrap().xyz()
+            *self.adsorbate().atoms().xyz_coords().get(0).unwrap()
         };
         let translate_mat = Translation3::from(Point3::origin() - curr_stem_centroid);
         self.adsorbate_mut().translate(&translate_mat);
     }
     fn flip_up(&mut self, upper_atom_id: u32) {
-        let cd_atom_z = self
-            .adsorbate()
-            .get_atom_by_id(self.coord_atom_ids()[0])
+        let cd_atom_z = get_xyz_by_id(self.adsorbate().atoms(), self.coord_atom_ids()[0])
             .unwrap()
-            .xyz()
             .z;
-        if self
-            .adsorbate()
-            .get_atom_by_id(upper_atom_id)
+        if get_xyz_by_id(self.adsorbate().atoms(), upper_atom_id)
             .unwrap()
-            .xyz()
             .z
             < cd_atom_z
         {
@@ -450,8 +415,7 @@ where
         }
     }
     fn check_coordinate(&self) -> Result<(), InvalidCoord> {
-        for atom in self.adsorbate().atoms() {
-            let xyz = atom.xyz();
+        for xyz in self.adsorbate().atoms().xyz_coords() {
             if xyz.x.is_nan() || xyz.y.is_nan() || xyz.z.is_nan() {
                 return Err(InvalidCoord());
             }
@@ -529,10 +493,11 @@ where
 
 impl<'a, T: ModelInfo> AdsorptionBuilder<'a, T, Imported> {
     pub fn with_location_at_sites(mut self, target_sites: &[u32]) -> Self {
-        let target_sites_points: Vec<&Point3<f64>> = target_sites
-            .iter()
-            .map(|&site_id| self.host_lattice.get_atom_by_id(site_id).unwrap().xyz())
-            .collect();
+        let target_sites_points: Vec<&Point3<f64>> =
+            get_multiple_xyz_by_id(self.host_lattice.atoms(), target_sites)
+                .into_iter()
+                .flatten()
+                .collect();
         let centroid = centroid_of_points(&target_sites_points);
         self.location = Some(centroid);
         self
@@ -580,11 +545,8 @@ where
     /// The logic for pitch do not differ on type of stem.
     fn pitch_ads(&mut self) {
         let stem_vector: Vector3<f64> = self.get_stem_vector().into();
-        let coord_atom_xyz = self
-            .adsorbate()
-            .get_atom_by_id(self.coord_atom_ids()[0])
-            .unwrap()
-            .xyz();
+        let coord_atom_xyz =
+            get_xyz_by_id(self.adsorbate().atoms(), self.coord_atom_ids()[0]).unwrap();
         let origin_to_coord = coord_atom_xyz - Point3::origin();
         // Compute dot product of `stem_vector` and `origin_to_coord` to see if they are in same x-direction
         let stem_dot_oc = origin_to_coord.dot(&stem_vector);
@@ -662,7 +624,7 @@ where
         };
         self.adsorbate_mut().rotate(&rotate_quatd);
         self.move_to_origin();
-        let ads_atom_nums = self.adsorbate().atoms().len();
+        let ads_atom_nums = self.adsorbate().atoms().size();
         match ads_atom_nums {
             1 => {} // No need to rotate a single atom
             _ => {
@@ -713,7 +675,7 @@ impl<'a, T: ModelInfo> AdsorptionBuilder<'a, T, Calibrated> {
         let ads = self.adsorbate();
         let location = self.location();
         let coord_atom_id = self.coord_atom_ids()[0];
-        let coord_atom_point = ads.get_atom_by_id(coord_atom_id).unwrap().xyz();
+        let coord_atom_point = get_xyz_by_id(ads.atoms(), coord_atom_id).unwrap();
         let vertical_proj_from_coord_atom = Vector3::new(0.0, 0.0, self.bond_length());
         // Create a stem_vector guaranteed to be pointing upwards
         let stem_vector: Vector3<f64> = self.get_coord_stem_vector();
@@ -747,7 +709,7 @@ impl<'a, T: ModelInfo> AdsorptionBuilder<'a, T, Calibrated> {
             let coord_atom_points: Vec<&Point3<f64>> = self
                 .coord_atom_ids()
                 .iter()
-                .map(|&coord_id| ads.get_atom_by_id(coord_id).unwrap().xyz())
+                .map(|&coord_id| get_xyz_by_id(ads.atoms(), coord_id).unwrap())
                 .collect();
             let coord_centroid = centroid_of_points(&coord_atom_points);
             location.z += self.bond_length();

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,12 +10,15 @@ mod test {
         CellModel, LatticeModel, MsiModel,
     };
     use nalgebra::Vector3;
-    use std::fs::{read_to_string, write};
+    use std::{
+        fs::{read_to_string, write},
+        str::FromStr,
+    };
 
     #[test]
     fn test_conversion() {
         let test_lat = read_to_string("SAC_GDY_Ag.msi").unwrap();
-        let msi_lat: LatticeModel<MsiModel> = LatticeModel::try_from(test_lat.as_str()).unwrap();
+        let msi_lat: LatticeModel<MsiModel> = LatticeModel::from_str(&test_lat).unwrap();
         let cell_lat: LatticeModel<CellModel> = msi_lat.into();
         let msi_back: LatticeModel<MsiModel> = cell_lat.into();
         write("SAC_GDY_Ag_back.msi", msi_back.msi_export()).unwrap();
@@ -32,10 +35,10 @@ mod test {
         seed_name: &str,
     ) {
         let test_lat = read_to_string("SAC_GDY_Ag.msi").unwrap();
-        let lat = LatticeModel::<MsiModel>::try_from(test_lat.as_str()).unwrap();
+        let lat = LatticeModel::<MsiModel>::from_str(test_lat.as_str()).unwrap();
         let test_ad = read_to_string(ads_name).unwrap();
-        let ads = LatticeModel::<MsiModel>::try_from(test_ad.as_str()).unwrap();
-        let ads_direction: Option<Vector3<f64>> = if ads.atoms().len() == 1 {
+        let ads = LatticeModel::<MsiModel>::from_str(test_ad.as_str()).unwrap();
+        let ads_direction: Option<Vector3<f64>> = if ads.atoms().size() == 1 {
             None
         } else if target_sites.len() == 1 {
             Some(lat.get_vector_ab(41_u32, 42_u32).unwrap())


### PR DESCRIPTION
- Adapt to api changes
- Use `castep-model-core` 0.2.*
